### PR TITLE
Enforcing the pre-computed level when generating dependencies

### DIFF
--- a/daggen.c
+++ b/daggen.c
@@ -136,7 +136,19 @@ static void generateDependencies(DAG dag) {
       nb_parents = MIN(1 + (int)getRandomNumberBetween(0.0,
           global.density * (dag->nb_tasks_per_level[i-1])),
           dag->nb_tasks_per_level[i-1]);
-      for (k=0; k<nb_parents; k++) {
+      
+      /* at least one parent from the previous level,
+       * to enforce the pre-computed level*/
+      parent_index = (int)getRandomNumberBetween(0.0,
+          (double)(dag->nb_tasks_per_level[i-1]));
+      parent = dag->levels[i-1][parent_index];
+      /* update the parent's children list*/
+      parent->children = (Task *)realloc(parent->children,
+          (parent->nb_children+1)*sizeof(Task));
+      parent->children[(parent->nb_children)] = dag->levels[i][j];
+      (parent->nb_children)++;
+
+      for (k=0; k<nb_parents-1; k++) {
         /* compute the level of the parent */
         parent_level = (i-(int)getRandomNumberBetween( 1.0,
             (double)global.jump+1));


### PR DESCRIPTION
The original code suffers from a probable inconsistency between the nodes topology decided by `generateTasks` and that of the actual generated DAG.

Explanation:

In the task scheduling literature, the _level_ of a node (task) `n` is usually defined as [1]:

> The maximum number of edges of the paths from the entry node to node `n`

In DAGGEN, the nodes topology (i.e. the number of nodes in each level) is first decided by `generateTasks`, but it is not enforced later when generating the edges in `generateDependencies`. More specifically, by considering the above definition of _level_, a non-entry node that was decided to belong to level `i` might end up belonging to any level between `[Max(1, i-jump+1), i]` in the generated DAG. In other words, for `jump > 1` the generated DAG is probable to have a drastically different nodes topology from what was decided by `generateTasks`.

To enforce the nodes topology decided by `generateTasks`, every node in level `i` should have at least one parent in level `i-1`.

Side note: I also could not think of any other definition for _level_ using which does not result in the explained probable inconsistency between the nodes topology decided by `generateTasks` and that of the generated DAG.


[1] H. Arabnejad and J. G. Barbosa, "List Scheduling Algorithm for Heterogeneous Systems by an Optimistic Cost Table," in IEEE Transactions on Parallel and Distributed Systems, vol. 25, no. 3, pp. 682-694, March 2014, doi: 10.1109/TPDS.2013.57.